### PR TITLE
Remove "exclude" field from WarpPolicy struct

### DIFF
--- a/src/registration.rs
+++ b/src/registration.rs
@@ -140,7 +140,7 @@ struct WarpPolicy {
     allow_updates: bool,
     support_url: String,
     // TODO: Value
-    exclude: Value,
+    // exclude: Value, // Not currently required.
     gateway_unique_id: String,
     allow_mode_switch: bool,
     auto_connect: u8,


### PR DESCRIPTION
This PR resolves #7 by removing "exclude" from the WarpPolicy struct (as it is not used elsewhere in the code).