### PR TITLE
[BUG FIX] Fix Int overflow in registration

### DIFF
--- a/src/registration.rs
+++ b/src/registration.rs
@@ -143,7 +143,7 @@ struct WarpPolicy {
     // exclude: Value, // Not currently required.
     gateway_unique_id: String,
     allow_mode_switch: bool,
-    auto_connect: u8,
+    auto_connect: u16,
     disable_auto_fallback: bool,
     organization: String,
 }


### PR DESCRIPTION
Recently (Jan 2024) wgcf-teams has been returning the blow error and unable to register new clients.
Its a simple single line fix increasing the auto connect to a u16
Solves #9 

Error: Failed to parse the result returned by cloudflare

Caused by:
    0: error decoding response body: invalid value: integer `3600`, expected u8 at line 1 column 1131
    1: invalid value: integer `3600`, expected u8 at line 1 column 1131